### PR TITLE
added PROJECT and GIT_SHORT_HASH to shell info

### DIFF
--- a/convex/cortex/fw/vexshell.c
+++ b/convex/cortex/fw/vexshell.c
@@ -79,6 +79,9 @@
 #define HISTORY_CHAR          '!'
 #define ESC                   0x1B
 
+#define xstr(a) str(a)
+#define str(a) #a
+
 // Shell termination event source.
 EventSource shell_terminated;
 
@@ -162,6 +165,12 @@ cmd_info(vexStream *chp, int argc, char *argv[])
 #ifdef __TIME__
     vex_chprintf(chp, "Build time:   %s%s%s\r\n", __DATE__, " - ", __TIME__);
 #endif
+#endif
+#ifdef PROJECT
+    vex_chprintf(chp, "Project:      %s\r\n",xstr(PROJECT));
+#endif
+#ifdef GIT_SHORT_HASH
+    vex_chprintf(chp, "Git Hash:     %s\r\n",xstr(GIT_SHORT_HASH));
 #endif
 }
 


### PR DESCRIPTION
planning to use convex for a VEX team that shares robots.  Having the easy ability to tell what code is running on a robot via the shell is incredibly useful.  Build the target code with PROJECT set and add 
"GIT_SHORT_HASH = $(shell git log -1 --pretty=format:%h)" to your makefile and the info command will return the project name and short hash to uniquely identify the actual code running.
